### PR TITLE
fix null reference to "track" when importing the listening history

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -43,5 +43,5 @@ jobs:
         with:
           context: .
           push: true
-          # 2. We reference the output from the 'prep' step
+          target: app 
           tags: ghcr.io/${{ steps.prep.outputs.repo }}:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Build and Push Docker Image
 
 on:
   push:
-    branches: [ "main" ] # Or "master", whichever your branch is named
+    branches: [ "main" ]
 
 jobs:
   build:
@@ -15,6 +15,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # 1. We create an output called 'repo' in a step with the ID 'prep'
+      - name: Lowercase repo name
+        id: prep
+        run: echo "repo=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
@@ -23,6 +28,7 @@ jobs:
           cache: maven
 
       - name: Build with Maven
+        working-directory: sysh-server 
         run: mvn clean package -DskipTests
 
       - name: Log in to GitHub Container Registry
@@ -37,4 +43,5 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository_lowercased }}:latest
+          # 2. We reference the output from the 'prep' step
+          tags: ghcr.io/${{ steps.prep.outputs.repo }}:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,40 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ "main" ] # Or "master", whichever your branch is named
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build with Maven
+        run: mvn clean package -DskipTests
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository_lowercased }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM eclipse-temurin:21-jre AS app
+WORKDIR /app
+# This copies your compiled JAR into the /app folder
 COPY sysh-server/target/sysh-server-*.jar app.jar
-COPY .env /app/.env
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+# This copies the .env into the /app folder
+COPY .env .env 
+ENTRYPOINT ["java", "-jar", "app.jar"]
 
 FROM postgres:latest AS postgres
 COPY sysh-server/schema.sql /docker-entrypoint-initdb.d/schema.sql

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21 AS app
+FROM eclipse-temurin:21-jre AS app
 COPY sysh-server/target/sysh-server-*.jar app.jar
 COPY .env /app/.env
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM eclipse-temurin:21-jre AS app
 WORKDIR /app
-# This copies your compiled JAR into the /app folder
+# Only copy the JAR file
 COPY sysh-server/target/sysh-server-*.jar app.jar
-# This copies the .env into the /app folder
-COPY .env .env 
+# No COPY .env line here!
 ENTRYPOINT ["java", "-jar", "app.jar"]
 
 FROM postgres:latest AS postgres

--- a/sysh-server/src/main/java/com/github/barmiro/sysh_server/catalog/AddToCatalog.java
+++ b/sysh-server/src/main/java/com/github/barmiro/sysh_server/catalog/AddToCatalog.java
@@ -116,6 +116,9 @@ public class AddToCatalog {
 		albumsTracks.updateJoinTable(tracks);
 		
 		for (ApiTrack apiTrack:apiTracks) {
+			if (apiTrack == null) {
+				continue;
+			}
 			for (ApiTrackArtist artist:apiTrack.artists()) {
 				artistIDs.add(artist.id());
 			}

--- a/sysh-server/src/main/java/com/github/barmiro/sysh_server/catalog/AddToCatalog.java
+++ b/sysh-server/src/main/java/com/github/barmiro/sysh_server/catalog/AddToCatalog.java
@@ -103,6 +103,9 @@ public class AddToCatalog {
 		
 		List <ApiTrackAlbum> apiTrackAlbums = new ArrayList<>();
 		for (ApiTrack apiTrack:apiTracks) {
+			if (apiTrack == null) {
+				continue;
+			}
 			if (!apiTrackAlbums.contains(apiTrack.album())) {
 				apiTrackAlbums.add(apiTrack.album());				
 			}

--- a/sysh-server/src/main/java/com/github/barmiro/sysh_server/catalog/interfaces/SpotifyApiRepository.java
+++ b/sysh-server/src/main/java/com/github/barmiro/sysh_server/catalog/interfaces/SpotifyApiRepository.java
@@ -147,8 +147,12 @@ public abstract class SpotifyApiRepository<
             label = "SpotifyApiRepository.getResponse"
         )
 	protected ResponseEntity<String> getResponse(String packet, String username) {
-		
-		
+		try {
+			Thread.sleep(1000); 
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+
 		ResponseEntity<String> response = apiClient
 				.get()
 				.uri(packet)

--- a/sysh-server/src/main/java/com/github/barmiro/sysh_server/catalog/jointables/TracksArtists.java
+++ b/sysh-server/src/main/java/com/github/barmiro/sysh_server/catalog/jointables/TracksArtists.java
@@ -38,8 +38,11 @@ public class TracksArtists {
 		
 		int added = 0;
 		for (ApiTrack apiTrack:apiTracks) {
-			List<ApiTrackArtist> artists = apiTrack.artists();
+			if (apiTrack == null) {
+				continue;
+			}
 			
+			List<ApiTrackArtist> artists = apiTrack.artists();
 			
 			for(int i = 0; i < artists.size(); i++) {
 				

--- a/sysh-server/src/main/java/com/github/barmiro/sysh_server/catalog/tracks/spotify_api/TrackApiRepository.java
+++ b/sysh-server/src/main/java/com/github/barmiro/sysh_server/catalog/tracks/spotify_api/TrackApiRepository.java
@@ -55,14 +55,6 @@ public class TrackApiRepository extends SpotifyApiRepository<
 		
 		List<ApiTrack> apiTracks = new ArrayList<>();
 		for (String packet:packets) {
-			try {
-				// Sleep for 1000ms (1 second) between batches
-				Thread.sleep(1000); 
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-				log.error("Thread was interrupted", e);
-			}
-
 			ResponseEntity<String> response = getResponse(packet, username);
 			
 			if (response == null) {

--- a/sysh-server/src/main/java/com/github/barmiro/sysh_server/catalog/tracks/spotify_api/TrackApiRepository.java
+++ b/sysh-server/src/main/java/com/github/barmiro/sysh_server/catalog/tracks/spotify_api/TrackApiRepository.java
@@ -36,18 +36,34 @@ public class TrackApiRepository extends SpotifyApiRepository<
 
 	public List<ApiTrack> getApiTracks(List<String> track_ids, String username) throws JsonProcessingException, ClassCastException {
 		
-		List<String> newIDs = getNewIDs(track_ids, "spotify_track_id");
-		log.info("Found " + newIDs.size() + " new tracks.");
-		List<String> packets = new ArrayList<>();
-		
-		packets = prepIdPackets(newIDs, 50);			
+		// Safety check: ensure we have IDs to look for
+		if (track_ids == null || track_ids.isEmpty()) {
+			return new ArrayList<>();
+		}
 
+		// Defensive: Make sure we aren't looking up the same ID twice in one go
+		List<String> uniqueIds = track_ids.stream().distinct().toList();
+
+		List<String> newIDs = getNewIDs(uniqueIds, "spotify_track_id");
+		log.info("Found " + newIDs.size() + " new tracks.");
+
+		if (newIDs.isEmpty()) {
+			return new ArrayList<>();
+		}
+
+		List<String> packets = prepIdPackets(newIDs, 50);
 		
 		List<ApiTrack> apiTracks = new ArrayList<>();
 		for (String packet:packets) {
-			
-			ResponseEntity<String> response = null;
-			response = getResponse(packet, username);
+			try {
+				// Sleep for 1000ms (1 second) between batches
+				Thread.sleep(1000); 
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				log.error("Thread was interrupted", e);
+			}
+
+			ResponseEntity<String> response = getResponse(packet, username);
 			
 			if (response == null) {
 				log.error("Response for " + packet + " is null.");
@@ -68,11 +84,17 @@ public class TrackApiRepository extends SpotifyApiRepository<
 		
 	public List<Track> addNewTracks (List<ApiTrack> apiTracks) throws IllegalAccessException, InvocationTargetException {
 		
+		// If there's nothing to add, stop here to prevent NPEs in ConvertDTOs
+		if (apiTracks == null || apiTracks.isEmpty()) {
+			return new ArrayList<>();
+		}
+
 		List<Track> tracks = ConvertDTOs.apiTracks(apiTracks);
 		
-		catalogRepository.addTracks(tracks);
+		if (tracks != null && !tracks.isEmpty()) {
+			catalogRepository.addTracks(tracks);
+		}
 		
-		return tracks;
-		
+		return tracks != null ? tracks : new ArrayList<>();
 	}
 }

--- a/sysh-server/src/main/java/com/github/barmiro/sysh_server/common/utils/ConvertDTOs.java
+++ b/sysh-server/src/main/java/com/github/barmiro/sysh_server/common/utils/ConvertDTOs.java
@@ -99,7 +99,6 @@ public class ConvertDTOs {
 		if (apiTracks == null) return addedTracks;
 
 		for (ApiTrack track:apiTracks) {
-
 			if (track == null) {
 				continue; 
 			}

--- a/sysh-server/src/main/java/com/github/barmiro/sysh_server/common/utils/ConvertDTOs.java
+++ b/sysh-server/src/main/java/com/github/barmiro/sysh_server/common/utils/ConvertDTOs.java
@@ -96,7 +96,18 @@ public class ConvertDTOs {
 		
 		List<Track> addedTracks = new ArrayList<>();
 		
+		if (apiTracks == null) return addedTracks;
+
 		for (ApiTrack track:apiTracks) {
+
+			if (track == null) {
+				continue; 
+			}
+
+			if (track.album() == null) {
+				continue;
+			}
+			
 			String spotify_track_id = track.id();
 			String name = track.name();
 			Integer duration_ms = track.duration_ms();


### PR DESCRIPTION
When importing 9 years of the listening history, 2 files failed, and in the logs I can find this error:

```
sysh              | java.lang.NullPointerException: Cannot invoke "com.github.barmiro.sysh_server.catalog.tracks.spotify_api.dto.tracks.ApiTrack.id()" because "track" is null
sysh              |     at com.github.barmiro.sysh_server.common.utils.ConvertDTOs.apiTracks(ConvertDTOs.java:100)
sysh              |     at com.github.barmiro.sysh_server.catalog.tracks.spotify_api.TrackApiRepository.addNewTracks(TrackApiRepository.java:71)
sysh              |     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
sysh              |     at java.base/java.lang.reflect.Method.invoke(Method.java:580)
sysh              |     at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:359)
sysh              |     at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196)
sysh              |     at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
sysh              |     at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:138)
sysh              |     at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
sysh              |     at org.springframework.retry.annotation.AnnotationAwareRetryOperationsInterceptor.invoke(AnnotationAwareRetryOperationsInterceptor.java:165)
sysh              |     at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
sysh              |     at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:728)
sysh              |     at com.github.barmiro.sysh_server.catalog.tracks.spotify_api.TrackApiRepository$$SpringCGLIB$$0.addNewTracks(<generated>)
sysh              |     at com.github.barmiro.sysh_server.catalog.AddToCatalog.adder(AddToCatalog.java:100)
sysh              |     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
sysh              |     at java.base/java.lang.reflect.Method.invoke(Method.java:580)
sysh              |     at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:359)
sysh              |     at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196)
sysh              |     at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
sysh              |     at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:138)
sysh              |     at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
sysh              |     at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:380)
sysh              |     at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
sysh              |     at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
sysh              |     at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:728)
sysh              |     at com.github.barmiro.sysh_server.catalog.AddToCatalog$$SpringCGLIB$$0.adder(<generated>)
sysh              |     at com.github.barmiro.sysh_server.dataintake.json.JsonController.lambda$uploadZip$0(JsonController.java:185)
sysh              |     at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
sysh              |     at java.base/java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1796)
sysh              |     at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
sysh              |     at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
sysh              |     at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
sysh              |     at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
sysh              |     at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
```

I propose this change that skips the tracks that return as null from the Spotify API.